### PR TITLE
ss3diags ssplot parameter deprecation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ss3diags
 Title: What the Package Does (One Line, Title Case)
-Version: 1.0.8.9001
+Version: 1.0.8.9002
 Authors@R: 
     c(person(given = "Henning",
            family = "Winker",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ss3diags
-Title: What the Package Does (One Line, Title Case)
+Title: Stock Synthesis Model Diagnostics for Intergated Stock Assessments
 Version: 1.0.8.9002
 Authors@R: 
     c(person(given = "Henning",

--- a/R/SSplotEnsemble.R
+++ b/R/SSplotEnsemble.R
@@ -8,9 +8,14 @@
 #' @param ylabs yaxis labels for quants
 #' final year of values to show for each model. By default it is set to the
 #' @param endyrvec ending year specified in each model.
-#' @param plot plot to active plot device?
-#' @param print print to PNG files?
-#' @param pdf not tested for TRUE
+#' @param plot plot to active plot device? Deprecated. Please use show_plot.
+#' @param show_plot Option to draw subplots and plot in the interface.
+#' @param print print to PNG files? Deprecated. Please use print_plot. 
+#' @param print_plot print to PNG files?
+#' @param pdf not tested for TRUE. Deprecated. Please use use_pdf.
+#' @param use_pdf option for pdf plots (not tested for TRUE)
+#' @param png output in PNG format. Deprecated. Please use use_png.
+#' @param use_png Draw plots in PNG format
 #' @param col Optional vector of colors to be used for lines. Input NULL
 #' @param pch Optional vector of plot character values
 #' @param lty Optional vector of line types
@@ -49,11 +54,10 @@
 #' @param verbose Report progress to R GUI?
 #' @param shadecol uncertainty shading of hcxval horizon
 #' @param shadealpha Transparency adjustment used to make default shadecol
-#' @param new Create new empty plot window
+#' @param new Create new empty plot window. Deprecated.
 #' @param add surpresses par() to create multiplot figs
 #' @param summaryoutput List created by r4ss::SSummarize(). TODO: Verify
 #' @param quantiles quantile TODO TODO. Default is (.025,.075)
-#' @param png png TODO TODO Default is prinf ??
 #' @param xylabs xylabs X asis and Y axis labels TODO TODO. Default in NULL !
 #' @param uncertainty uncertainty TODO TODO. Default is TRUE
 #' @param mcmcVec mcmc vector TODO TODO. Default is FALSE
@@ -63,6 +67,7 @@
 #' @importFrom grDevices graphics.off rgb adjustcolor dev.new dev.off 
 #' @importFrom graphics polygon abline axis box
 #' @importFrom stats dnorm
+#' @importFrom lifecycle deprecated
 #' 
 #' @author Mostly adopted from r4ss::SSplotComparisons by Taylor et al
 #' 
@@ -74,10 +79,14 @@ SSplotEnsemble<- function(kb, summaryoutput,
                         quantiles = c(0.025,0.975),
                         ylabs = NULL,
                         endyrvec="default",
-                        plot=TRUE,
-                        print=FALSE,
-                        png=print,
+                        plot=deprecated(),
+                        show_plot=TRUE,
+                        print=deprecated(),
+                        print_plot=FALSE,
+                        png=deprecated(),
+                        use_png=print_plot,
                         pdf=FALSE,
+                        use_pdf=FALSE,
                         col=NULL, 
                         pch=NULL,
                         lty=1, 
@@ -116,14 +125,44 @@ SSplotEnsemble<- function(kb, summaryoutput,
                         indexQdigits=4,
                         legendindex=NULL
                         ){ # plot different fits to a single index of abundance
+  
+  #Parameter DEPRECATION checks 
+  if (lifecycle::is_present(print)){
+    lifecycle::deprecate_warn("1.0.9","SSplotEnsemble(print)","SSplotEnsemble(print_plot)")
+    print_plot <- print
+  }
+  
+  if(lifecycle::is_present(png)){
+    lifecycle::deprecate_warn("1.0.9", "SSplotEnsemble(png)","SSplotEnsemble(use_png)")
+    use_png <- png
+  }
+  
+  if(lifecycle::is_present(pdf)){
+    lifecycle::deprecate_warn("1.0.9", "SSplotEnsemble(pdf)","SSplotEnsemble(use_pdf)")
+    use_pdf <- pdf
+  }
+  
+  if(lifecycle::is_present(plot)){
+    lifecycle::deprecate_warn("1.0.9","SSplotModelcomp(plot)","SSplotModelcomp(show_plot)")
+    show_plot <- plot
+  }
+  
+  if(!isTRUE(new)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotModelcomp(new)",
+      details = "This parameter is not used in this function, and will be removed in a future version"
+    )
+  }
+  
   #------------------------------------------
   # r4ss plotting functions
   #------------------------------------------
   # subfunction to write png files
   if(!add) graphics.off()
   if(add){
-    print=F
-    png=F
+    print_plot=F
+    use_png=F
   }
   
   if(is.null(ylabs)){
@@ -154,15 +193,15 @@ SSplotEnsemble<- function(kb, summaryoutput,
   }
   
 
-  if(png) print <- TRUE
-  if(png & is.null(plotdir))
+  if(use_png) print_plot <- TRUE
+  if(use_png & is.null(plotdir))
     stop("to print PNG files, you must supply a directory as 'plotdir'")
   
   # check for internal consistency
-  if(pdf & png){
-    stop("To use 'pdf', set 'print' or 'png' to FALSE.")
+  if(use_pdf & use_png){
+    stop("To use 'use_pdf', set 'print_plot' or 'use_png' to FALSE.")
   }
-  if(pdf){
+  if(use_pdf){
     if(is.null(plotdir)){
       stop("to write to a PDF, you must supply a directory as 'plotdir'")
     }
@@ -179,15 +218,15 @@ SSplotEnsemble<- function(kb, summaryoutput,
   
   plot_quants <- function(quant="SSB"){  
     
-    if(png) print <- TRUE
-    if(png & is.null(plotdir))
+    if(use_png) print_plot <- TRUE
+    if(use_png & is.null(plotdir))
       stop("to print PNG files, you must supply a directory as 'plotdir'")
     
     # check for internal consistency
-    if(pdf & png){
-      stop("To use 'pdf', set 'print' or 'png' to FALSE.")
+    if(use_pdf & use_png){
+      stop("To use 'use_pdf', set 'print_plot' or 'use_png' to FALSE.")
     }
-    if(pdf){
+    if(use_pdf){
       if(is.null(plotdir)){
         stop("to write to a PDF, you must supply a directory as 'plotdir'")
       }
@@ -281,7 +320,7 @@ SSplotEnsemble<- function(kb, summaryoutput,
     if(legendorder[1]=="default") legendorder <- 1:(nlines)
     
     # open new window if requested
-    if(plot & png==FALSE){
+    if(show_plot & use_png==FALSE){
       if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       
     } else {
@@ -349,10 +388,10 @@ SSplotEnsemble<- function(kb, summaryoutput,
   legend.temp = legend  
   
   # Do plotting
-  if(plot){ 
+  if(show_plot){ 
       # subplots
       for(s in 1:length(subplots)){
-        if(print){
+        if(print_plot){
           quant=subplots[s]
           par(par)
           pngfun(paste0("ModelComp_",quant,".png",sep=""))
@@ -383,7 +422,7 @@ SSplotEnsemble<- function(kb, summaryoutput,
             legendcex = legendcex,
             legendsp = legendsp,
             shadealpha = shadealpha,
-            use_png = png,
+            use_png = use_png,
             pheight = pheight,
             ptsize = ptsize,
             ylimAdj = ylimAdj,
@@ -391,7 +430,8 @@ SSplotEnsemble<- function(kb, summaryoutput,
             xylabs = xylabs,
             quant_s = quant,
             indexQdigits = indexQdigits,
-            tickEndYr = tickEndYr
+            tickEndYr = tickEndYr,
+            show_plot_window = show_plot
           )
           ensemble_plot_index(summaryoutput, varlist_fleet_plot_index, indexfleets, verbose)   
           legend = legend.temp 
@@ -509,7 +549,7 @@ ensemble_plot_index <- function(summaryoutput, varlist, indexfleets=1, verbose=T
   if(legendorder[1]=="default") legendorder <- 1:nlines
   
   # open new window if requested
-  if(plot & varlist[["use_png"]]==FALSE){
+  if(varlist[["show_plot_window"]] & varlist[["use_png"]]==FALSE){
     # "Add" param does not pass through this function, negating its check.
     dev.new(width=varlist[["pwidth"]],
             height=varlist[["pheight"]],

--- a/R/SSplotEnsemble.R
+++ b/R/SSplotEnsemble.R
@@ -151,7 +151,7 @@ SSplotEnsemble<- function(kb, summaryoutput,
     lifecycle::deprecate_warn(
       when = "1.0.9",
       what = "SSplotModelcomp(new)",
-      details = "This parameter is not used in this function, and will be removed in a future version"
+      details = "The ability to explicitly disable new plot windows is unused and will be removed in a future version"
     )
   }
   

--- a/R/SSplotEnsemble.R
+++ b/R/SSplotEnsemble.R
@@ -8,8 +8,7 @@
 #' @param ylabs yaxis labels for quants
 #' final year of values to show for each model. By default it is set to the
 #' @param endyrvec ending year specified in each model.
-#' @param plot plot to active plot device? Deprecated. Please use show_plot.
-#' @param show_plot Option to draw subplots and plot in the interface.
+#' @param plot Option to draw subplots and plot in the interface. Deprecated. Option to disable will be removed in future version.
 #' @param print print to PNG files? Deprecated. Please use print_plot. 
 #' @param print_plot print to PNG files?
 #' @param pdf not tested for TRUE. Deprecated. Please use use_pdf.
@@ -79,8 +78,7 @@ SSplotEnsemble<- function(kb, summaryoutput,
                         quantiles = c(0.025,0.975),
                         ylabs = NULL,
                         endyrvec="default",
-                        plot=deprecated(),
-                        show_plot=TRUE,
+                        plot=TRUE,
                         print=deprecated(),
                         print_plot=FALSE,
                         png=deprecated(),
@@ -142,15 +140,18 @@ SSplotEnsemble<- function(kb, summaryoutput,
     use_pdf <- pdf
   }
   
-  if(lifecycle::is_present(plot)){
-    lifecycle::deprecate_warn("1.0.9","SSplotModelcomp(plot)","SSplotModelcomp(show_plot)")
-    show_plot <- plot
+  if(!isTRUE(plot)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotEnsemble(plot)",
+      details = "The ability to explictly disable plot windows or plot subplots is unused and will be removed in a future version"
+    )
   }
-  
+    
   if(!isTRUE(new)){
     lifecycle::deprecate_warn(
       when = "1.0.9",
-      what = "SSplotModelcomp(new)",
+      what = "SSplotEnsemble(new)",
       details = "The ability to explicitly disable new plot windows is unused and will be removed in a future version"
     )
   }
@@ -320,7 +321,7 @@ SSplotEnsemble<- function(kb, summaryoutput,
     if(legendorder[1]=="default") legendorder <- 1:(nlines)
     
     # open new window if requested
-    if(show_plot & use_png==FALSE){
+    if(plot & use_png==FALSE){
       if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       
     } else {
@@ -388,7 +389,7 @@ SSplotEnsemble<- function(kb, summaryoutput,
   legend.temp = legend  
   
   # Do plotting
-  if(show_plot){ 
+  if(plot){ 
       # subplots
       for(s in 1:length(subplots)){
         if(print_plot){
@@ -431,7 +432,7 @@ SSplotEnsemble<- function(kb, summaryoutput,
             quant_s = quant,
             indexQdigits = indexQdigits,
             tickEndYr = tickEndYr,
-            show_plot_window = show_plot
+            show_plot_window = plot
           )
           ensemble_plot_index(summaryoutput, varlist_fleet_plot_index, indexfleets, verbose)   
           legend = legend.temp 

--- a/R/SSplotHCxval.R
+++ b/R/SSplotHCxval.R
@@ -162,7 +162,7 @@ SSplotHCxval<- function(retroSummary,
   if(!isTRUE(plot)){
     lifecycle::deprecate_warn(
       when = "1.0.9",
-      what = "SSplotHCxval(new)",
+      what = "SSplotHCxval(plot)",
       details = "The ability to explictly disable plot windows or plot subplots is unused and will be removed in a future version"
     )
   }

--- a/R/SSplotHCxval.R
+++ b/R/SSplotHCxval.R
@@ -171,7 +171,7 @@ SSplotHCxval<- function(retroSummary,
     lifecycle::deprecate_warn(
       when = "1.0.9",
       what = "SSplotHCxval(new)",
-      details = "This ability to explicitly disable new plot windows is unused and will be removed in a future version"
+      details = "The ability to explicitly disable new plot windows is unused and will be removed in a future version"
     )
   }
   

--- a/R/SSplotHCxval.R
+++ b/R/SSplotHCxval.R
@@ -20,9 +20,13 @@
 #' @param indexfleets CHECK IF NEEDED or how to adjust indexfleets
 #' @param xmin optional number first year shown in plot (if available)  
 #' @param indexUncertainty Show fixed uncertainty intervals on index (not estimated)
-#' @param plot plot to active plot device?
-#' @param print print to PNG files?
-#' @param pdf not tested for TRUE
+#' @param plot plot to active plot device? Deprecated. 
+#' @param print print to PNG files? Deprecated. Please use print_plot.
+#' @param print_plot Option to print to PNG files
+#' @param png png plots. Deprecated, please use use_png
+#' @param use_png Draw plots in PNG format
+#' @param pdf PDF plots (not tested for TRUE). Deprecated. Please use use_pdf.
+#' @param use_pdf option for pdf plots (not tested for TRUE)
 #' @param col Optional vector of colors to be used for lines. Input NULL
 #' @param pch Optional vector of plot character values
 #' @param lty Optional vector of line types
@@ -67,7 +71,6 @@
 #' @param indexQlabel Add catchability to legend in plot of index fits (TRUE/FALSE)?
 #' @param indexQdigits Number of significant digits for catchability in legend
 #' @param shadealpha Transparancy adjustment used to make default shadecol. TODO: verify 
-#' @param png png TODO TODO. Default is FALSE
 #' @param xlim xlim TODO TODO. 
 #' @param xylabs x-axis and y-axis labels ?? Default is TRUE
 #' @param uncertainty uncertainty TODO TODO. Default is TRUE
@@ -77,14 +80,18 @@
 #' 
 #' @importFrom grDevices grey 
 #' @importFrom stats qnorm qlnorm
+#' @importFrom lifecycle deprecated
 #' 
 #' @export
 SSplotHCxval<- function(retroSummary,
                         subplots=c("cpue","len","age"),
                         Season="default",
-                        print=FALSE,
-                        png=print,
-                        pdf=FALSE,
+                        print=deprecated(),
+                        print_plot=FALSE,
+                        png=deprecated(),
+                        use_png=print_plot,
+                        pdf=deprecated(),
+                        use_pdf=FALSE,
                         models="all",
                         endyrvec="default",
                         xmin = NULL,
@@ -127,13 +134,49 @@ SSplotHCxval<- function(retroSummary,
                         shadecol2=grey(0.5,0.4),
                         shadealpha=0.3,
                         new=TRUE,
-                        add=FALSE,mcmcVec=FALSE,
+                        add=FALSE,
+                        mcmcVec=FALSE,
                         indexQlabel=TRUE,
                         indexQdigits=4,
                         indexfleets=1,
                         plot=TRUE,
                         shadecol1=grey(0.5,0.4)
                         ){ # plot different fits to a single index of abundance
+  
+  #Parameter DEPRECATION checks 
+  if (lifecycle::is_present(print)){
+    lifecycle::deprecate_warn("1.0.9","SSplotHCxval(print)","SSplotHCxcval(print_plot)")
+    print_plot <- print
+  }
+  
+  if(lifecycle::is_present(png)){
+    lifecycle::deprecate_warn("1.0.9", "SSplotHCxval(png)","SSplotHCxcval(use_png)")
+    use_png <- png
+  }
+  
+  if(lifecycle::is_present(pdf)){
+    lifecycle::deprecate_warn("1.0.9", "SSplotHCxval(pdf)","SSplotHCxval(use_pdf)")
+    use_pdf <- pdf
+  }
+  
+  if(!isTRUE(plot)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotHCxval(new)",
+      details = "The ability to explictly disable plot windows or plot subplots is unused and will be removed in a future version"
+    )
+  }
+  
+  if(!isTRUE(new)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotHCxval(new)",
+      details = "This ability to explicitly disable new plot windows is unused and will be removed in a future version"
+    )
+  }
+  
+  
+  
   #------------------------------------------
   # r4ss plotting functions
   #------------------------------------------
@@ -189,15 +232,15 @@ SSplotHCxval<- function(retroSummary,
   
    
     
-    if(png) print <- TRUE
-    if(png & is.null(plotdir))
+    if(use_png) print_plot <- TRUE
+    if(use_png & is.null(plotdir))
       stop("to print PNG files, you must supply a directory as 'plotdir'")
     
     # check for internal consistency
-    if(pdf & png){
-      stop("To use 'pdf', set 'print' or 'png' to FALSE.")
+    if(use_pdf & use_png){
+      stop("To use 'use_pdf', set 'print_plot' or 'use_png' to FALSE.")
     }
-    if(pdf){
+    if(use_pdf){
       if(is.null(plotdir)){
         stop("to write to a PDF, you must supply a directory as 'plotdir'")
       }
@@ -305,7 +348,7 @@ SSplotHCxval<- function(retroSummary,
     if(legendorder[1]=="default") legendorder <- 1:nlines
     
     # open new window if requested
-    if(plot & png==FALSE){
+    if(plot & use_png==FALSE){
       if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       
     } else {
@@ -521,7 +564,7 @@ SSplotHCxval<- function(retroSummary,
       if(verbose) cat(paste0("\n","No observations in evaluation years to compute prediction residuals for Index ",indices2$Fleet_name[1]),"\n")
       MASE.i = NULL
       MASE.i = data.frame(Index=unique(indices2$Fleet_name)[1],Season=Season, MASE=NA,MAE.PR=NA,MAE.base=NA,MASE.adj=NA,n.eval=0)
-      if(png==FALSE & add==FALSE) dev.off()
+      if(use_png==FALSE & add==FALSE) dev.off()
     }
     return(list(MASE=MASE.i))
   } # End of plot_hcxval function  
@@ -531,7 +574,7 @@ SSplotHCxval<- function(retroSummary,
   if(plot){ 
     # LOOP through fleets
     nfleets=length(unique(hcruns$indices$Fleet))
-    if(print){
+    if(print_plot){
       
       MASE = NULL
       for(fi in 1:nfleets){

--- a/R/SSplotJABBAres.R
+++ b/R/SSplotJABBAres.R
@@ -4,9 +4,13 @@
 #' 
 #' @param ss3rep from r4ss::SS_output
 #' @param subplots optional use of cpue and comp data (only tested for length) 
-#' @param plot plot to active plot device?
-#' @param print print to PNG files?
-#' @param pdf not tested for TRUE
+#' @param plot plot to active plot device? Deprecated.
+#' @param print print to PNG files? Deprecated. Please use print_plot.
+#' @param print_plot Option to print to PNG files
+#' @param png png plots. Deprecated, please use use_png
+#' @param use_png Draw plots in PNG format
+#' @param pdf PDF plots (not tested for TRUE). Deprecated. Please use use_pdf.
+#' @param use_pdf option for pdf plots (not tested for TRUE)
 #' @param indexselect Vector of fleet numbers for each model for which to compare
 #' @param miny  minimum abs values of ylim
 #' @param col Optional vector of colors to be used for lines. Input NULL
@@ -45,9 +49,8 @@
 #' @param par list of graphics parameter values passed to par() function
 #' @param verbose Report progress to R GUI?
 #' @param boxcol color boxes 
-#' @param new Create new empty plot window
+#' @param new Create new empty plot window. Deprecated.
 #' @param add surpresses par() to create multiplot figs
-#' @param png png TODO TODO, Default is FALSE
 #' @param xlim xlim TODO TODO, 
 #' @param xylabs xylabs TODO TODO. Default is TRUE
 #' 
@@ -56,14 +59,18 @@
 #' @importFrom grDevices grey
 #' @importFrom graphics boxplot 
 #' @importFrom stats predict loess runif
+#' @importFrom lifecycle deprecated
 #' 
 #' @export
 SSplotJABBAres<- function(ss3rep=ss3diags::ss3sma,
                           subplots=c("cpue","len","age")[1],
                           plot=TRUE,
-                          print=FALSE,
-                          png=print,
-                          pdf=FALSE,
+                          print=deprecated(),
+                          print_plot=FALSE,
+                          png=deprecated(),
+                          use_png=print_plot,
+                          pdf=deprecated(),
+                          use_pdf=FALSE,
                           indexselect=NULL,
                           miny = 3,
                           col=NULL, 
@@ -95,17 +102,52 @@ SSplotJABBAres<- function(ss3rep=ss3diags::ss3sma,
                           filenameprefix="",
                           par=list(mar=c(5,4,1,1)+.1),
                           verbose=TRUE,
-                          boxcol =  grey(0.8,0.5),
+                          boxcol = grey(0.8,0.5),
                           new=TRUE,
                           add=FALSE){ 
+  
+  
+  #Parameter DEPRECATION checks 
+  if (lifecycle::is_present(print)){
+    lifecycle::deprecate_warn("1.0.9","SSplotJABBAres(print)","SSplotJABBAres(print_plot)")
+    print_plot <- print
+  }
+  
+  if(lifecycle::is_present(png)){
+    lifecycle::deprecate_warn("1.0.9", "SSplotJABBAres(png)","SSplotJABBAres(use_png)")
+    use_png <- png
+  }
+  
+  if(lifecycle::is_present(pdf)){
+    lifecycle::deprecate_warn("1.0.9", "SSplotJABBAres(pdf)","SSplotJABBAres(use_pdf)")
+    use_pdf <- pdf
+  }
+  
+  if(!isTRUE(plot)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotJABBAres(new)",
+      details = "The ability to explictly disable plot windows or plot subplots is unused and will be removed in a future version"
+    )
+  }
+  
+  if(!isTRUE(new)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotJABBAres(new)",
+      details = "The ability to explicitly disable new plot windows is unused and will be removed in a future version"
+    )
+  }
+  
+  
   #------------------------------------------
   # r4ss plotting functions
   #------------------------------------------
   # subfunction to write png files
   if(!add) graphics.off()
   if(add){
-    print=F
-    png=F
+    print_plot=F
+    use_png=F
   }
   
   subplots = subplots[1]
@@ -159,15 +201,15 @@ SSplotJABBAres<- function(ss3rep=ss3diags::ss3sma,
   if(is.null(legendindex))  legendindex=series
   if(!legend) legendindex=10000
   
-  if(png) print <- TRUE
-  if(png & is.null(plotdir))
-    stop("to print PNG files, you must supply a directory as 'plotdir'")
+  if(use_png) print_plot <- TRUE
+  if(use_png & is.null(plotdir))
+    stop("to print_plot PNG files, you must supply a directory as 'plotdir'")
   
   # check for internal consistency
-  if(pdf & png){
-    stop("To use 'pdf', set 'print' or 'png' to FALSE.")
+  if(use_pdf & use_png){
+    stop("To use 'use_pdf', set 'print_plot' or 'use_png' to FALSE.")
   }
-  if(pdf){
+  if(use_pdf){
     if(is.null(plotdir)){
       stop("to write to a PDF, you must supply a directory as 'plotdir'")
     }
@@ -223,7 +265,7 @@ SSplotJABBAres<- function(ss3rep=ss3diags::ss3sma,
              "Residuals")         #2
                
     # open new window if requested
-    if(plot & png==FALSE){
+    if(plot & use_png==FALSE){
       if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       
     } else {
@@ -250,7 +292,7 @@ SSplotJABBAres<- function(ss3rep=ss3diags::ss3sma,
     if(legendorder[1]=="default") legendorder <- 1:(n.indices+1)
     
     # open new window if requested
-    if(plot & png==FALSE){
+    if(plot & use_png==FALSE){
       if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       
     } else {
@@ -305,7 +347,7 @@ SSplotJABBAres<- function(ss3rep=ss3diags::ss3sma,
   
   if(verbose) cat("Plotting JABBA residual plot \n")
   if(plot){ 
-    if(print){
+    if(print_plot){
       
          pngfun(paste0("jabbaresidual.png",sep=""))
          par(par)

--- a/R/SSplotJABBAres.R
+++ b/R/SSplotJABBAres.R
@@ -126,7 +126,7 @@ SSplotJABBAres<- function(ss3rep=ss3diags::ss3sma,
   if(!isTRUE(plot)){
     lifecycle::deprecate_warn(
       when = "1.0.9",
-      what = "SSplotJABBAres(new)",
+      what = "SSplotJABBAres(plot)",
       details = "The ability to explictly disable plot windows or plot subplots is unused and will be removed in a future version"
     )
   }

--- a/R/SSplotModelcomp.R
+++ b/R/SSplotModelcomp.R
@@ -136,12 +136,12 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     print_plot <- print
   }
   
-  if(lifecycle::is_present("png")){
+  if(lifecycle::is_present(png)){
     lifecycle::deprecate_warn("1.0.9", "SSplotModelcomp(png)","SSplotModelcomp(use_png)")
     use_png <- png
   }
   
-  if(lifecycle::is_present("pdf")){
+  if(lifecycle::is_present(pdf)){
     lifecycle::deprecate_warn("1.0.9", "SSplotModelcomp(pdf)","SSplotModelcomp(use_pdf)")
     use_pdf <- pdf
   }
@@ -154,7 +154,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     )
   }
   
-  if(lifecycle::is_present("plot")){
+  if(lifecycle::is_present(plot)){
     lifecycle::deprecate_warn("1.0.9","SSplotModelcomp(plot)","SSplotModelcomp(show_plot)")
     show_plot <- plot
   }

--- a/R/SSplotModelcomp.R
+++ b/R/SSplotModelcomp.R
@@ -58,7 +58,7 @@
 #' @param verbose Report progress to R GUI?
 #' @param shadecol uncertainty shading of hcxval horizon
 #' @param shadealpha Transparency adjustment used to make default shadecol
-#' @param new Create new empty plot window
+#' @param new Create new empty plot window. Deprecated.
 #' @param add surpresses par() to create multiplot figs
 #' @param mcmcVec NOT TESTED Vector of TRUE/FALSE values (or single value) indicating
 #' @param indexQlabel Add catchability to legend in plot of index fits (TRUE/FALSE)?
@@ -142,6 +142,14 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
   if(lifecycle::is_present("pdf")){
     lifecycle::deprecate_warn("1.0.8", "SSplotModelcomp(pdf)","SSplotModelcomp(use_pdf)")
     use_pdf <- pdf
+  }
+  
+  if(!isTRUE(new)){
+    lifecycle::deprecate_warn(
+      when = "1.0.8",
+      what = "SSplotModelcomp(new)",
+      details = "This parameter is not used in this function, and will be removed in a future version"
+    )
   }
   
   

--- a/R/SSplotModelcomp.R
+++ b/R/SSplotModelcomp.R
@@ -419,9 +419,14 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
       subexp <- indices2[["imodel"]]==imodel & yr>= xmin
       if(iline==1){
         if(indexUncertainty){
-          arrows(x0=yr[subset], y0=lower[subset], 
-                 x1=yr[subset], y1=upper[subset],
-                 length=0.02, angle=90, code=3, col=1)
+          arrows(x0=yr[subset], 
+                 y0=lower[subset], 
+                 x1=yr[subset], 
+                 y1=upper[subset],
+                 length=0.02, 
+                 angle=90, 
+                 code=3, 
+                 col=1)
           }
         points(yr[subset],obs[subset],pch=21,cex=1,bg="white")
       }
@@ -621,7 +626,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     
     # Check if uncertainty is measured
     if(uncertainty ==TRUE & sum(exp[,1]-lower[,1])==0){
-      if(verbose) cat("No uncertainty estimates available from the provided")
+      if(verbose) message("No uncertainty estimates available from the provided")
       uncertainty=FALSE
     }
     
@@ -664,9 +669,14 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
                   col=shadecol[iline],border=shadecol[iline])
         } else {
           adj <- 0.2*iline/nlines - 0.1
-          arrows(x0=yr+adj, y0=lower[,iline],
-          x1=yr+adj, y1=upper[,iline],
-          length=0.02, angle=90, code=3, col=col[iline])
+          arrows(x0=yr+adj, 
+                 y0=lower[,iline],
+                 x1=yr+adj, 
+                 y1=upper[,iline],
+                 length=0.02, 
+                 angle=90, 
+                 code=3, 
+                 col=col[iline])
         }
       }
     }
@@ -728,7 +738,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     
     # subplots
     for(s in 1:length(subplots)){
-      if(verbose) cat(paste0("\n","Plot Comparison of ",subplots[s],"\n"))
+      if(verbose) message(paste0("Plot Comparison of ",subplots[s]))
       if(subplots[s]!="Index"){  
         if(!add)par(par)
         quant=subplots[s]

--- a/R/SSplotModelcomp.R
+++ b/R/SSplotModelcomp.R
@@ -16,8 +16,7 @@
 #' @param indexselect = Vector of fleet numbers for each model for which to compare
 #' @param indexfleets CHECK IF NEEDED or how to adjust indexfleets
 #' @param indexUncertainty Show fixed uncertainty intervals on index (not estimated)
-#' @param plot plot to active plot device? Deprecated.
-#' @param show_plot Option to draw subplots and plot in the interface.
+#' @param plot Option to draw subplots and plot in the interface. Deprecated. Option to disable will be removed in future version.
 #' @param print print to PNG. Deprecated.
 #' @param print_plot print to PNG files?
 #' @param pdf draw in PDF(not tested for TRUE). Deprecated
@@ -74,8 +73,7 @@
 #' @importFrom grDevices pdf
 #' @importFrom lifecycle deprecated
 SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
-                        plot=deprecated(),
-                        show_plot=TRUE,
+                        plot=TRUE,
                         print=deprecated(),
                         print_plot=FALSE,
                         png=deprecated(),
@@ -145,6 +143,14 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     lifecycle::deprecate_warn("1.0.9", "SSplotModelcomp(pdf)","SSplotModelcomp(use_pdf)")
     use_pdf <- pdf
   }
+
+  if(!isTRUE(plot)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotModelcomp(plot)",
+      details = "The ability to explictly disable plot windows or plot subplots is unused and will be removed in a future version"
+    )
+  }
   
   if(!isTRUE(new)){
     lifecycle::deprecate_warn(
@@ -153,12 +159,6 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
       details = "The ability to explicitly disable new plot windows is unused and will be removed in a future version"
     )
   }
-  
-  if(lifecycle::is_present(plot)){
-    lifecycle::deprecate_warn("1.0.9","SSplotModelcomp(plot)","SSplotModelcomp(show_plot)")
-    show_plot <- plot
-  }
-  
   
   #------------------------------------------
   # r4ss plotting functions
@@ -334,7 +334,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     if(legendorder[1]=="default") legendorder <- 1:nlines
     
     # open new window if requested
-    if(show_plot & use_png==FALSE){
+    if(plot & use_png==FALSE){
       if(!add) {
         dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       }
@@ -622,7 +622,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     if(legendorder[1]=="default") legendorder <- 1:(nlines)
     
     # open new window if requested
-    if(show_plot & use_png==FALSE){
+    if(plot & use_png==FALSE){
       if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       
     } else {
@@ -715,7 +715,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
   } # End of plot_quant function  
   legend.temp = legend  
   # Do plotting
-  if(show_plot){ 
+  if(plot){ 
     # subplots
     for(s in 1:length(subplots)){
       if(print_plot){

--- a/R/SSplotModelcomp.R
+++ b/R/SSplotModelcomp.R
@@ -150,7 +150,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     lifecycle::deprecate_warn(
       when = "1.0.9",
       what = "SSplotModelcomp(new)",
-      details = "This parameter is not used in this function, and will be removed in a future version"
+      details = "The ability to explicitly disable new plot windows is unused and will be removed in a future version"
     )
   }
   

--- a/R/SSplotModelcomp.R
+++ b/R/SSplotModelcomp.R
@@ -16,7 +16,8 @@
 #' @param indexselect = Vector of fleet numbers for each model for which to compare
 #' @param indexfleets CHECK IF NEEDED or how to adjust indexfleets
 #' @param indexUncertainty Show fixed uncertainty intervals on index (not estimated)
-#' @param plot plot to active plot device?
+#' @param plot plot to active plot device? Deprecated.
+#' @param show_plot Option to draw subplots and plot in the interface.
 #' @param print print to PNG. Deprecated.
 #' @param print_plot print to PNG files?
 #' @param pdf draw in PDF(not tested for TRUE). Deprecated
@@ -73,7 +74,8 @@
 #' @importFrom grDevices pdf
 #' @importFrom lifecycle deprecated
 SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
-                        plot=TRUE,
+                        plot=deprecated(),
+                        show_plot=TRUE,
                         print=deprecated(),
                         print_plot=FALSE,
                         png=deprecated(),
@@ -130,26 +132,31 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
   
   #Parameter DEPRECATION checks 
   if (lifecycle::is_present(print)){
-    lifecycle::deprecate_warn("1.0.8","SSplotModelcomp(print)","SSplotModelcomp(print_plot)")
+    lifecycle::deprecate_warn("1.0.9","SSplotModelcomp(print)","SSplotModelcomp(print_plot)")
     print_plot <- print
   }
   
   if(lifecycle::is_present("png")){
-    lifecycle::deprecate_warn("1.0.8", "SSplotModelcomp(png)","SSplotModelcomp(use_png)")
+    lifecycle::deprecate_warn("1.0.9", "SSplotModelcomp(png)","SSplotModelcomp(use_png)")
     use_png <- png
   }
   
   if(lifecycle::is_present("pdf")){
-    lifecycle::deprecate_warn("1.0.8", "SSplotModelcomp(pdf)","SSplotModelcomp(use_pdf)")
+    lifecycle::deprecate_warn("1.0.9", "SSplotModelcomp(pdf)","SSplotModelcomp(use_pdf)")
     use_pdf <- pdf
   }
   
   if(!isTRUE(new)){
     lifecycle::deprecate_warn(
-      when = "1.0.8",
+      when = "1.0.9",
       what = "SSplotModelcomp(new)",
       details = "This parameter is not used in this function, and will be removed in a future version"
     )
+  }
+  
+  if(lifecycle::is_present("plot")){
+    lifecycle::deprecate_warn("1.0.9","SSplotModelcomp(plot)","SSplotModelcomp(show_plot)")
+    show_plot <- plot
   }
   
   
@@ -327,7 +334,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     if(legendorder[1]=="default") legendorder <- 1:nlines
     
     # open new window if requested
-    if(plot & use_png==FALSE){
+    if(show_plot & use_png==FALSE){
       if(!add) {
         dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       }
@@ -615,7 +622,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
     if(legendorder[1]=="default") legendorder <- 1:(nlines)
     
     # open new window if requested
-    if(plot & use_png==FALSE){
+    if(show_plot & use_png==FALSE){
       if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       
     } else {
@@ -708,7 +715,7 @@ SSplotModelcomp<- function(summaryoutput=ss3diags::aspm.sma,
   } # End of plot_quant function  
   legend.temp = legend  
   # Do plotting
-  if(plot){ 
+  if(show_plot){ 
     # subplots
     for(s in 1:length(subplots)){
       if(print_plot){

--- a/R/SSplotRetro.R
+++ b/R/SSplotRetro.R
@@ -157,7 +157,7 @@ SSplotRetro<- function(summaryoutput,
     lifecycle::deprecate_warn(
       when = "1.0.9",
       what = "SSplotRetro(new)",
-      details = "This parameter is not used in this function, and will be removed in a future version"
+      details = "The ability to explicitly disable new plot windows is unused and will be removed in a future version"
     )
   }
   

--- a/R/SSplotRetro.R
+++ b/R/SSplotRetro.R
@@ -10,8 +10,7 @@
 #' final year of values to show for each model. By default it is set to the
 #' ending year specified in each model.
 #' @param subplots Vector of subplots to be created
-#' @param plot plot to active plot device? Deprecated, please use show_plot.
-#' @param show_plot Option to draw subplots and plot in the interface.
+#' @param plot Option to draw subplots and plot in the interface. Deprecated. Option to disable will be removed in future version.
 #' @param print print to PNG files? Deprecated. Please use print_plot.
 #' @param print_plot Option to print to PNG files
 #' @param png png plots. Deprecated, please use use_png
@@ -75,8 +74,7 @@
 #' @export
 SSplotRetro<- function(summaryoutput, 
                        subplots=c("SSB","F"),
-                       plot=deprecated(),
-                       show_plot=TRUE,
+                       plot=TRUE,
                        print=deprecated(),
                        print_plot=FALSE,
                        png=deprecated(),
@@ -147,10 +145,13 @@ SSplotRetro<- function(summaryoutput,
     lifecycle::deprecate_warn("1.0.9","SSplotRetro(png)","SSplotRetro(use_png)")
     use_png <- png
   }
-  
-  if(lifecycle::is_present(plot)){
-    lifecycle::deprecate_warn("1.0.9","SSplotRetro(plot)","SSplotRetro(show_plot)")
-    show_plot <- plot
+
+  if(!isTRUE(plot)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotRetro(plot)",
+      details = "The ability to explictly disable plot windows or plot subplots is unused and will be removed in a future version"
+    )
   }
   
   if(!isTRUE(new)){
@@ -317,7 +318,7 @@ SSplotRetro<- function(summaryoutput,
     if(legendorder[1]=="default") legendorder <- 1:(nlines)
     
     # open new window if requested
-    if(show_plot & use_png==FALSE){
+    if(plot & use_png==FALSE){
       if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       
     } else {
@@ -426,7 +427,7 @@ SSplotRetro<- function(summaryoutput,
   #------------------------------------------------------------
   
   if(verbose) cat("Plotting Retrospective pattern \n")
-  if(show_plot){ 
+  if(plot){ 
     if(print_plot){
       
         pngfun(paste0("retro_",quant,".png",sep=""))

--- a/R/SSplotRetro.R
+++ b/R/SSplotRetro.R
@@ -10,9 +10,14 @@
 #' final year of values to show for each model. By default it is set to the
 #' ending year specified in each model.
 #' @param subplots Vector of subplots to be created
-#' @param plot plot to active plot device?
-#' @param print print to PNG files?
-#' @param pdf not tested for TRUE
+#' @param plot plot to active plot device? Deprecated, please use show_plot.
+#' @param show_plot Option to draw subplots and plot in the interface.
+#' @param print print to PNG files? Deprecated. Please use print_plot.
+#' @param print_plot Option to print to PNG files
+#' @param png png plots. Deprecated, please use use_png
+#' @param use_png Draw plots in PNG format
+#' @param pdf PDF plots (not tested for TRUE). Deprecated. Please use use_pdf.
+#' @param use_pdf option for pdf plots (not tested for TRUE)
 #' @param xlim  optional xlim, which overwrites xmin   
 #' @param xmin  optional minimum year shown in plot (default first yr)   
 #' @param labels yaxis lable for biomass (bony fish and sharks) 
@@ -56,24 +61,28 @@
 #' @param verbose Report progress to R GUI?
 #' @param shadecol uncertainty shading of hcxval horizon
 #' @param shadecol1 uncertainty shading of early years not affected by hindcast
-#' @param new Create new empty plot window
+#' @param new Create new empty plot window. Deprecated.
 #' @param add surpresses par() to create multiplot figs
 #' @param mcmcVec NOT TESTED Vector of TRUE/FALSE values (or single value) indicating
 #' @param indexQlabel Add catchability to legend in plot of index fits (TRUE/FALSE)?
 #' @param indexQdigits Number of significant digits for catchability in legend
-#' @param png png TODO TOO. Defaults to FALSE
 #' @param showrho showrho TODO TODO. Defaults to TRUE
 #' @param xylabs Draw x and y axis lables (?) TODO TODO. Defaults to TRUE
 #' @param uncertainty uncertainty TODO TODO. Defaults to TRUE.
 #' @param shadealpha shadealpha TODO TODO. Defalut to 0.3
 #' @author Henning Winker (JRC-EC) and Laurance Kell (Sea++)
+#' @importFrom lifecycle deprecated
 #' @export
 SSplotRetro<- function(summaryoutput, 
                        subplots=c("SSB","F"),
-                       plot=TRUE,
-                       print=FALSE,
-                       png=print,
-                       pdf=FALSE,
+                       plot=deprecated(),
+                       show_plot=TRUE,
+                       print=deprecated(),
+                       print_plot=FALSE,
+                       png=deprecated(),
+                       use_png=print_plot,
+                       pdf=deprecated(),
+                       use_pdf=FALSE,
                        models="all",
                        endyrvec="default",
                        xlim = NULL,
@@ -122,6 +131,36 @@ SSplotRetro<- function(summaryoutput,
                        indexQdigits = 4,
                        shadealpha=0.3
 ){ 
+  
+  # Parameter Deprecation Checks
+  if(lifecycle::is_present(print)){
+    lifecycle::deprecate_warn("1.0.9","SSplotRetro(print)","SSplotRetro(print_plot)")
+    print_plot <- print
+  }
+  
+  if(lifecycle::is_present(pdf)){
+    lifecycle::deprecate_warn("1.0.9","SSplotRetro(pdf)","SSplorRetro(use_pdf)")
+    use_pdf <- pdf
+  }
+  
+  if(lifecycle::is_present(png)) {
+    lifecycle::deprecate_warn("1.0.9","SSplotRetro(png)","SSplotRetro(use_png)")
+    use_png <- png
+  }
+  
+  if(lifecycle::is_present(plot)){
+    lifecycle::deprecate_warn("1.0.9","SSplotRetro(plot)","SSplotRetro(show_plot)")
+    show_plot <- plot
+  }
+  
+  if(!isTRUE(new)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotRetro(new)",
+      details = "This parameter is not used in this function, and will be removed in a future version"
+    )
+  }
+  
   #------------------------------------------
   # r4ss plotting functions
   #------------------------------------------
@@ -148,15 +187,15 @@ SSplotRetro<- function(summaryoutput,
   #------------------------------------------------------------------
   plot_retro <- function(quant=quant){  
     
-    if(png) print <- TRUE
-    if(png & is.null(plotdir))
+    if(use_png) print_plot <- TRUE
+    if(use_png & is.null(plotdir))
       stop("to print PNG files, you must supply a directory as 'plotdir'")
     
     # check for internal consistency
-    if(pdf & png){
-      stop("To use 'pdf', set 'print' or 'png' to FALSE.")
+    if(use_pdf & use_png){
+      stop("To use 'use_pdf', set 'print_plot' or 'use_png' to FALSE.")
     }
-    if(pdf){
+    if(use_pdf){
       if(is.null(plotdir)){
         stop("to write to a PDF, you must supply a directory as 'plotdir'")
       }
@@ -278,7 +317,7 @@ SSplotRetro<- function(summaryoutput,
     if(legendorder[1]=="default") legendorder <- 1:(nlines)
     
     # open new window if requested
-    if(plot & png==FALSE){
+    if(show_plot & use_png==FALSE){
       if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
       
     } else {
@@ -387,8 +426,8 @@ SSplotRetro<- function(summaryoutput,
   #------------------------------------------------------------
   
   if(verbose) cat("Plotting Retrospective pattern \n")
-  if(plot){ 
-    if(print){
+  if(show_plot){ 
+    if(print_plot){
       
         pngfun(paste0("retro_",quant,".png",sep=""))
         par(par)

--- a/R/SSplotRunstest.R
+++ b/R/SSplotRunstest.R
@@ -47,8 +47,12 @@ ssruns_sig3 <- function(x,type=NULL,mixing="less") {
 #' @param indexselect Vector of fleet numbers for each model for which to compare
 #' @param miny  minimum abs values of ylim
 #' @param plot plot to active plot device?
-#' @param print print to PNG files?
-#' @param pdf not tested for TRUE
+#' @param print print to PNG files? Deprecated. Please use print_plot.
+#' @param print_plot Option to print to PNG files
+#' @param png png plots. Deprecated, please use use_png
+#' @param use_png Draw plots in PNG format
+#' @param pdf PDF plots (not tested for TRUE). Deprecated. Please use use_pdf.
+#' @param use_pdf option for pdf plots (not tested for TRUE)
 #' @param pch Optional vector of plot character values
 #' @param lty Optional vector of line types
 #' @param lwd Optional vector of line widths
@@ -76,20 +80,23 @@ ssruns_sig3 <- function(x,type=NULL,mixing="less") {
 #' @param verbose Report progress to R GUI?
 #' @param new Create new empty plot window
 #' @param add surpresses par() to create multiplot figs
-#' @param png png TODO TODO Defaults to print value
 #' @param xlim xlim TODO TODO
 #' @param xylabs draw x-axis and y-axis TODO TODO
 #' @return Runs Test p-values and sig3 limits
 #' @author Henning Winker (JRC-EC) and Laurance Kell (Sea++)
+#' @importFrom lifecycle deprecated
 #' @export
 
 SSplotRunstest <- function(ss3rep=ss3diags::ss3sma,
                            mixing="less",
                            subplots=c("cpue","len","age")[1],
                            plot=TRUE,
-                           print=FALSE,
-                           png=print,
-                           pdf=FALSE,
+                           print=deprecated(),
+                           print_plot=FALSE,
+                           png=deprecated(),
+                           use_png=print_plot,
+                           pdf=deprecated(),
+                           use_pdf=FALSE,
                            indexselect = NULL,
                            miny = 1,
                            pch=21, 
@@ -117,15 +124,48 @@ SSplotRunstest <- function(ss3rep=ss3diags::ss3sma,
                            verbose=TRUE,
                            new=TRUE,
                            add=FALSE){
+
+  #Parameter DEPRECATION checks 
+  if (lifecycle::is_present(print)){
+    lifecycle::deprecate_warn("1.0.9","SSplotRunstest(print)","SSplotRunstest(print_plot)")
+    print_plot <- print
+  }
   
+  if(lifecycle::is_present(png)){
+    lifecycle::deprecate_warn("1.0.9", "SSplotRunstest(png)","SSplotRunstest(use_png)")
+    use_png <- png
+  }
+  
+  if(lifecycle::is_present(pdf)){
+    lifecycle::deprecate_warn("1.0.9", "SSplotRunstest(pdf)","SSplotRunstest(use_pdf)")
+    use_pdf <- pdf
+  }
+  
+  if(!isTRUE(plot)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotRunsTest(plot)",
+      details = "The ability to explictly disable plot windows or plot subplots is unused and will be removed in a future version"
+    )
+  }
+  
+  if(!isTRUE(new)){
+    lifecycle::deprecate_warn(
+      when = "1.0.9",
+      what = "SSplotJABBAres(new)",
+      details = "The ability to explicitly disable new plot windows is unused and will be removed in a future version"
+    )
+  }
+  
+    
     #-------------------------------------------
     # r4ss plotting functions and coding style
     #-------------------------------------------
     # subfunction to write png files
     if(!add) graphics.off()
     if(add){
-      print=F
-      png=F
+      print_plot=F
+      use_png=F
     }
   
     subplots = subplots[1]
@@ -173,15 +213,15 @@ SSplotRunstest <- function(ss3rep=ss3diags::ss3sma,
     
     
     
-    if(png) print <- TRUE
-    if(png & is.null(plotdir))
+    if(use_png) print_plot <- TRUE
+    if(use_png & is.null(plotdir))
       stop("to print PNG files, you must supply a directory as 'plotdir'")
     
     # check for internal consistency
-    if(pdf & png){
-      stop("To use 'pdf', set 'print' or 'png' to FALSE.")
+    if(use_pdf & use_png){
+      stop("To use 'use_pdf', set 'print_plot' or 'use_png' to FALSE.")
     }
-    if(pdf){
+    if(use_pdf){
       if(is.null(plotdir)){
         stop("to write to a PDF, you must supply a directory as 'plotdir'")
       }
@@ -207,7 +247,7 @@ SSplotRunstest <- function(ss3rep=ss3diags::ss3sma,
       
     
       # open new window if requested
-      if(plot & png==FALSE){
+      if(plot & use_png==FALSE){
         if(!add) dev.new(width=pwidth,height=pheight,pointsize=ptsize,record=TRUE)
         
       } else {
@@ -265,7 +305,7 @@ SSplotRunstest <- function(ss3rep=ss3diags::ss3sma,
     if(plot){ 
       # LOOP through fleets
       nfleets=n.indices
-      if(print){
+      if(print_plot){
         
         runs = NULL
         for(fi in 1:nfleets){

--- a/man/SSplotEnsemble.Rd
+++ b/man/SSplotEnsemble.Rd
@@ -12,10 +12,14 @@ SSplotEnsemble(
   quantiles = c(0.025, 0.975),
   ylabs = NULL,
   endyrvec = "default",
-  plot = TRUE,
-  print = FALSE,
-  png = print,
+  plot = deprecated(),
+  show_plot = TRUE,
+  print = deprecated(),
+  print_plot = FALSE,
+  png = deprecated(),
+  use_png = print_plot,
   pdf = FALSE,
+  use_pdf = FALSE,
   col = NULL,
   pch = NULL,
   lty = 1,
@@ -71,13 +75,21 @@ final year of values to show for each model. By default it is set to the}
 
 \item{endyrvec}{ending year specified in each model.}
 
-\item{plot}{plot to active plot device?}
+\item{plot}{plot to active plot device? Deprecated. Please use show_plot.}
 
-\item{print}{print to PNG files?}
+\item{show_plot}{Option to draw subplots and plot in the interface.}
 
-\item{png}{png TODO TODO Default is prinf ??}
+\item{print}{print to PNG files? Deprecated. Please use print_plot.}
 
-\item{pdf}{not tested for TRUE}
+\item{print_plot}{print to PNG files?}
+
+\item{png}{output in PNG format. Deprecated. Please use use_png.}
+
+\item{use_png}{Draw plots in PNG format}
+
+\item{pdf}{not tested for TRUE. Deprecated. Please use use_pdf.}
+
+\item{use_pdf}{option for pdf plots (not tested for TRUE)}
 
 \item{col}{Optional vector of colors to be used for lines. Input NULL}
 
@@ -149,7 +161,7 @@ It will be separated from default name by an underscore.}
 
 \item{shadealpha}{Transparency adjustment used to make default shadecol}
 
-\item{new}{Create new empty plot window}
+\item{new}{Create new empty plot window. Deprecated.}
 
 \item{add}{surpresses par() to create multiplot figs}
 

--- a/man/SSplotEnsemble.Rd
+++ b/man/SSplotEnsemble.Rd
@@ -12,8 +12,7 @@ SSplotEnsemble(
   quantiles = c(0.025, 0.975),
   ylabs = NULL,
   endyrvec = "default",
-  plot = deprecated(),
-  show_plot = TRUE,
+  plot = TRUE,
   print = deprecated(),
   print_plot = FALSE,
   png = deprecated(),
@@ -75,9 +74,7 @@ final year of values to show for each model. By default it is set to the}
 
 \item{endyrvec}{ending year specified in each model.}
 
-\item{plot}{plot to active plot device? Deprecated. Please use show_plot.}
-
-\item{show_plot}{Option to draw subplots and plot in the interface.}
+\item{plot}{Option to draw subplots and plot in the interface. Deprecated. Option to disable will be removed in future version.}
 
 \item{print}{print to PNG files? Deprecated. Please use print_plot.}
 

--- a/man/SSplotHCxval.Rd
+++ b/man/SSplotHCxval.Rd
@@ -8,9 +8,12 @@ SSplotHCxval(
   retroSummary,
   subplots = c("cpue", "len", "age"),
   Season = "default",
-  print = FALSE,
-  png = print,
-  pdf = FALSE,
+  print = deprecated(),
+  print_plot = FALSE,
+  png = deprecated(),
+  use_png = print_plot,
+  pdf = deprecated(),
+  use_pdf = FALSE,
   models = "all",
   endyrvec = "default",
   xmin = NULL,
@@ -69,11 +72,17 @@ SSplotHCxval(
 
 \item{Season}{option to specify Season - Default uses first available, i.e. usual Seas = 1}
 
-\item{print}{print to PNG files?}
+\item{print}{print to PNG files? Deprecated. Please use print_plot.}
 
-\item{png}{png TODO TODO. Default is FALSE}
+\item{print_plot}{Option to print to PNG files}
 
-\item{pdf}{not tested for TRUE}
+\item{png}{png plots. Deprecated, please use use_png}
+
+\item{use_png}{Draw plots in PNG format}
+
+\item{pdf}{PDF plots (not tested for TRUE). Deprecated. Please use use_pdf.}
+
+\item{use_pdf}{option for pdf plots (not tested for TRUE)}
 
 \item{models}{Optional subset of the models described in
 r4ss function summaryoutput().  Either "all" or a vector of numbers indicating
@@ -181,7 +190,7 @@ It will be separated from default name by an underscore.}
 
 \item{indexfleets}{CHECK IF NEEDED or how to adjust indexfleets}
 
-\item{plot}{plot to active plot device?}
+\item{plot}{plot to active plot device? Deprecated.}
 
 \item{shadecol1}{uncertainty shading of early years not affected by hindcast}
 }

--- a/man/SSplotJABBAres.Rd
+++ b/man/SSplotJABBAres.Rd
@@ -8,9 +8,12 @@ SSplotJABBAres(
   ss3rep = ss3diags::ss3sma,
   subplots = c("cpue", "len", "age")[1],
   plot = TRUE,
-  print = FALSE,
-  png = print,
-  pdf = FALSE,
+  print = deprecated(),
+  print_plot = FALSE,
+  png = deprecated(),
+  use_png = print_plot,
+  pdf = deprecated(),
+  use_pdf = FALSE,
   indexselect = NULL,
   miny = 3,
   col = NULL,
@@ -52,13 +55,19 @@ SSplotJABBAres(
 
 \item{subplots}{optional use of cpue and comp data (only tested for length)}
 
-\item{plot}{plot to active plot device?}
+\item{plot}{plot to active plot device? Deprecated.}
 
-\item{print}{print to PNG files?}
+\item{print}{print to PNG files? Deprecated. Please use print_plot.}
 
-\item{png}{png TODO TODO, Default is FALSE}
+\item{print_plot}{Option to print to PNG files}
 
-\item{pdf}{not tested for TRUE}
+\item{png}{png plots. Deprecated, please use use_png}
+
+\item{use_png}{Draw plots in PNG format}
+
+\item{pdf}{PDF plots (not tested for TRUE). Deprecated. Please use use_pdf.}
+
+\item{use_pdf}{option for pdf plots (not tested for TRUE)}
 
 \item{indexselect}{Vector of fleet numbers for each model for which to compare}
 
@@ -132,7 +141,7 @@ It will be separated from default name by an underscore.}
 
 \item{boxcol}{color boxes}
 
-\item{new}{Create new empty plot window}
+\item{new}{Create new empty plot window. Deprecated.}
 
 \item{add}{surpresses par() to create multiplot figs}
 }

--- a/man/SSplotModelcomp.Rd
+++ b/man/SSplotModelcomp.Rd
@@ -173,7 +173,7 @@ It will be separated from default name by an underscore.}
 
 \item{shadealpha}{Transparency adjustment used to make default shadecol}
 
-\item{new}{Create new empty plot window}
+\item{new}{Create new empty plot window. Deprecated.}
 
 \item{add}{surpresses par() to create multiplot figs}
 

--- a/man/SSplotModelcomp.Rd
+++ b/man/SSplotModelcomp.Rd
@@ -6,8 +6,7 @@
 \usage{
 SSplotModelcomp(
   summaryoutput = ss3diags::aspm.sma,
-  plot = deprecated(),
-  show_plot = TRUE,
+  plot = TRUE,
   print = deprecated(),
   print_plot = FALSE,
   png = deprecated(),
@@ -67,9 +66,7 @@ SSplotModelcomp(
 \arguments{
 \item{summaryoutput}{List created by r4ss::SSsummarize()}
 
-\item{plot}{plot to active plot device? Deprecated.}
-
-\item{show_plot}{Option to draw subplots and plot in the interface.}
+\item{plot}{Option to draw subplots and plot in the interface. Deprecated. Option to disable will be removed in future version.}
 
 \item{print}{print to PNG. Deprecated.}
 

--- a/man/SSplotModelcomp.Rd
+++ b/man/SSplotModelcomp.Rd
@@ -6,7 +6,8 @@
 \usage{
 SSplotModelcomp(
   summaryoutput = ss3diags::aspm.sma,
-  plot = TRUE,
+  plot = deprecated(),
+  show_plot = TRUE,
   print = deprecated(),
   print_plot = FALSE,
   png = deprecated(),
@@ -66,7 +67,9 @@ SSplotModelcomp(
 \arguments{
 \item{summaryoutput}{List created by r4ss::SSsummarize()}
 
-\item{plot}{plot to active plot device?}
+\item{plot}{plot to active plot device? Deprecated.}
+
+\item{show_plot}{Option to draw subplots and plot in the interface.}
 
 \item{print}{print to PNG. Deprecated.}
 

--- a/man/SSplotRetro.Rd
+++ b/man/SSplotRetro.Rd
@@ -7,8 +7,7 @@
 SSplotRetro(
   summaryoutput,
   subplots = c("SSB", "F"),
-  plot = deprecated(),
-  show_plot = TRUE,
+  plot = TRUE,
   print = deprecated(),
   print_plot = FALSE,
   png = deprecated(),
@@ -68,9 +67,7 @@ SSplotRetro(
 
 \item{subplots}{Vector of subplots to be created}
 
-\item{plot}{plot to active plot device? Deprecated, please use show_plot.}
-
-\item{show_plot}{Option to draw subplots and plot in the interface.}
+\item{plot}{Option to draw subplots and plot in the interface. Deprecated. Option to disable will be removed in future version.}
 
 \item{print}{print to PNG files? Deprecated. Please use print_plot.}
 

--- a/man/SSplotRetro.Rd
+++ b/man/SSplotRetro.Rd
@@ -7,10 +7,14 @@
 SSplotRetro(
   summaryoutput,
   subplots = c("SSB", "F"),
-  plot = TRUE,
-  print = FALSE,
-  png = print,
-  pdf = FALSE,
+  plot = deprecated(),
+  show_plot = TRUE,
+  print = deprecated(),
+  print_plot = FALSE,
+  png = deprecated(),
+  use_png = print_plot,
+  pdf = deprecated(),
+  use_pdf = FALSE,
   models = "all",
   endyrvec = "default",
   xlim = NULL,
@@ -64,13 +68,21 @@ SSplotRetro(
 
 \item{subplots}{Vector of subplots to be created}
 
-\item{plot}{plot to active plot device?}
+\item{plot}{plot to active plot device? Deprecated, please use show_plot.}
 
-\item{print}{print to PNG files?}
+\item{show_plot}{Option to draw subplots and plot in the interface.}
 
-\item{png}{png TODO TOO. Defaults to FALSE}
+\item{print}{print to PNG files? Deprecated. Please use print_plot.}
 
-\item{pdf}{not tested for TRUE}
+\item{print_plot}{Option to print to PNG files}
+
+\item{png}{png plots. Deprecated, please use use_png}
+
+\item{use_png}{Draw plots in PNG format}
+
+\item{pdf}{PDF plots (not tested for TRUE). Deprecated. Please use use_pdf.}
+
+\item{use_pdf}{option for pdf plots (not tested for TRUE)}
 
 \item{models}{Optional subset of the models described in
 r4ss function summaryoutput().  Either "all" or a vector of numbers indicating
@@ -162,7 +174,7 @@ It will be separated from default name by an underscore.}
 
 \item{shadecol}{uncertainty shading of hcxval horizon}
 
-\item{new}{Create new empty plot window}
+\item{new}{Create new empty plot window. Deprecated.}
 
 \item{add}{surpresses par() to create multiplot figs}
 

--- a/man/SSplotRunstest.Rd
+++ b/man/SSplotRunstest.Rd
@@ -9,9 +9,12 @@ SSplotRunstest(
   mixing = "less",
   subplots = c("cpue", "len", "age")[1],
   plot = TRUE,
-  print = FALSE,
-  png = print,
-  pdf = FALSE,
+  print = deprecated(),
+  print_plot = FALSE,
+  png = deprecated(),
+  use_png = print_plot,
+  pdf = deprecated(),
+  use_pdf = FALSE,
   indexselect = NULL,
   miny = 1,
   pch = 21,
@@ -50,11 +53,17 @@ SSplotRunstest(
 
 \item{plot}{plot to active plot device?}
 
-\item{print}{print to PNG files?}
+\item{print}{print to PNG files? Deprecated. Please use print_plot.}
 
-\item{png}{png TODO TODO Defaults to print value}
+\item{print_plot}{Option to print to PNG files}
 
-\item{pdf}{not tested for TRUE}
+\item{png}{png plots. Deprecated, please use use_png}
+
+\item{use_png}{Draw plots in PNG format}
+
+\item{pdf}{PDF plots (not tested for TRUE). Deprecated. Please use use_pdf.}
+
+\item{use_pdf}{option for pdf plots (not tested for TRUE)}
 
 \item{indexselect}{Vector of fleet numbers for each model for which to compare}
 

--- a/tests/testthat/test-retro.R
+++ b/tests/testthat/test-retro.R
@@ -11,12 +11,13 @@ ss3diags::retro.phk
 retrosum.phk <- r4ss::SSsummarize(retro.phk)
 
 ## SSB
-test_that("Retrospective plot is created for SSB", {
+test_that("Retrospective plot is created for SSB (w/ deprecated parameters)", {
   
   SSplotRetro(retrosum.phk, 
               subplots = "SSB", 
               png = TRUE, 
-              print = T,
+              print = TRUE,
+              plot = TRUE,
               plotdir = path)
   
   expect_true(file.exists(file.path(path, "retro_SSB.png")))
@@ -24,13 +25,14 @@ test_that("Retrospective plot is created for SSB", {
   })
 
 ## F
-test_that("Retrospective plot is created for F", {
+test_that("Retrospective plot is created for F (w/ deprecated parameters)", {
   
 
   SSplotRetro(retrosum.phk, 
               subplots = "F", 
               png = TRUE, 
-              print = T,
+              print = TRUE,
+              plot = TRUE,
               plotdir = path)
   
   expect_true(file.exists(file.path(path, "retro_F.png")))


### PR DESCRIPTION
Resolves GH-8 via deprecation:. Original parameters will remain the for compatibility, but pack will warn the user of that these will replaced with a new parameter name or removed entirely in the future. 

- Mark ss3diags ssplot function parameters (print, pdf, png, new, plot) for deprecation
  - Mark new parameter `print_plot`to replace `print` in a future version
  - Mark new parameter `use_png` to replace `png` in a future version
  - Mark new parameter `use_pdf` to replace `pdf` in a future version
  - Mark parameter `plot` for deprecation. The ability to explicitly disable plot windows or plot subplots is unused and will be removed in a future version. Functionality under the default instance (TRUE) will remain.
  - Mark parameter `new` for deprecation. The ability to explicitly disable new plot windows is unused and will be removed in a future version. Functionality under the default instance (TRUE) will remain.
- Updated R package title in  `DESCRIPTION` 

